### PR TITLE
Generate namespaces using `JSONRPC.Introspect`

### DIFF
--- a/lib/kodi/client.rb
+++ b/lib/kodi/client.rb
@@ -4,7 +4,7 @@ module Kodi
 
     def initialize(uri)
       @uri = URI.parse(uri)
-      @namespaces = Namespace.generate_namespaces self
+      @namespaces = Namespace.generate_namespaces @uri
     end
 
     def method_missing(method_name, *arguments, &block)

--- a/lib/kodi/client.rb
+++ b/lib/kodi/client.rb
@@ -2,9 +2,9 @@ module Kodi
   class Client
     attr_reader :uri, :namespaces
 
-    def initialize(uri)
+    def initialize(uri, method_groups = nil)
       @uri = URI.parse(uri)
-      @namespaces = Namespace.generate_namespaces @uri
+      @namespaces = Namespace.generate_namespaces @uri, method_groups
     end
 
     def method_missing(method_name, *arguments, &block)

--- a/lib/kodi/client.rb
+++ b/lib/kodi/client.rb
@@ -4,7 +4,7 @@ module Kodi
 
     def initialize(uri)
       @uri = URI.parse(uri)
-      @namespaces = build_namespaces
+      @namespaces = Namespace.generate_namespaces self
     end
 
     def method_missing(method_name, *arguments, &block)
@@ -15,13 +15,6 @@ module Kodi
 
     def find_namespace(name)
       namespaces[name.to_s.camelize]
-    end
-
-    def build_namespaces
-      {
-        'Input' => Namespace.new(self, 'Input', 'Up', 'Down', 'Left', 'Right', 'Select', 'Back'),
-        'Player' => Namespace.new(self, 'Player', 'GetActivePlayers', 'PlayPause')
-      }
     end
   end
 end

--- a/lib/kodi/namespace.rb
+++ b/lib/kodi/namespace.rb
@@ -16,6 +16,20 @@ module Kodi
       end
     end
 
+    def self.generate_namespaces(client)
+      namespaces = Hash.new
+      api = RPC.new(client.uri).dispatch('JSONRPC.Introspect')
+      api['methods'].keys.each do |method|
+        parts = method.split('.')
+        if namespaces.has_key?(parts[0])
+          namespaces[parts[0]].append(parts[1])
+        else
+          namespaces[parts[0]] = [parts[1]]
+        end
+      end
+      namespaces.each { |name, methods| namespaces[name] = self.new(client, name, *methods) }
+    end
+
     private
 
     def find_method(name)

--- a/lib/kodi/namespace.rb
+++ b/lib/kodi/namespace.rb
@@ -1,24 +1,24 @@
 module Kodi
   class Namespace
-    attr_reader :client, :name
+    attr_reader :uri, :name
 
-    def initialize(client, name, *methods)
-      @client = client
+    def initialize(uri, name, *methods)
+      @uri = uri
       @name = name
       @methods = methods
     end
 
     def method_missing(method_name, *arguments, &block)
       if method = find_method(method_name)
-        RPC.new(client.uri).dispatch(name + '.' + method, *arguments)
+        RPC.new(uri).dispatch(name + '.' + method, *arguments)
       else
         super
       end
     end
 
-    def self.generate_namespaces(client)
+    def self.generate_namespaces(uri)
       namespaces = Hash.new
-      api = RPC.new(client.uri).dispatch('JSONRPC.Introspect')
+      api = RPC.new(uri).dispatch('JSONRPC.Introspect')
       api['methods'].keys.each do |method|
         parts = method.split('.')
         if namespaces.has_key?(parts[0])
@@ -27,7 +27,7 @@ module Kodi
           namespaces[parts[0]] = [parts[1]]
         end
       end
-      namespaces.each { |name, methods| namespaces[name] = self.new(client, name, *methods) }
+      namespaces.each { |name, methods| namespaces[name] = self.new(uri, name, *methods) }
     end
 
     private

--- a/lib/kodi/namespace.rb
+++ b/lib/kodi/namespace.rb
@@ -16,17 +16,21 @@ module Kodi
       end
     end
 
-    def self.generate_namespaces(uri)
-      namespaces = Hash.new
-      api = RPC.new(uri).dispatch('JSONRPC.Introspect')
-      api['methods'].keys.each do |method|
-        parts = method.split('.')
-        if namespaces.has_key?(parts[0])
-          namespaces[parts[0]].append(parts[1])
-        else
-          namespaces[parts[0]] = [parts[1]]
-        end
-      end
+    # Generates an Array of Namespaces for a particular URI
+    #
+    # Params
+    # +uri+::                       The URI of the Kodi JSON-RPC API server
+    # +method_groups+ (optional)::  A Hash where the key is the name of the created namespace and the value is an Array
+    #                               of the desired methods. A valid hash could be:
+    #                               {
+    #                                 'AudioLibrary' => ['GetArtists'],
+    #                                 'Input' => ['Up', 'Down', 'Left', 'Right', 'Select', 'Back'],
+    #                                 'Player' => ['GetActivePlayers', 'PlayPause']
+    #                               }
+    #                               If left empty, the complete API will be requested from the server. This will cost an
+    #                               extra second or two, but ensures that you have all methods available.
+    def self.generate_namespaces(uri, method_groups = nil)
+      namespaces = method_groups || request_methods(uri)
       namespaces.each { |name, methods| namespaces[name] = self.new(uri, name, *methods) }
     end
 
@@ -35,5 +39,25 @@ module Kodi
     def find_method(name)
       @methods.find { |m| m == name.to_s.camelize }
     end
+
+    # Calls the JSONRPC.Introspect method and uses the result to create a hash
+    # containing all methods that are available in the Kodi JSON-RPC API
+    #
+    # Params
+    # +uri+:: The URI of the Kodi JSON-RPC API server
+    def self.request_methods(uri)
+      method_groups = Hash.new
+      api = RPC.new(uri).dispatch('JSONRPC.Introspect')
+      api['methods'].keys.each do |method|
+        parts = method.split('.')
+        if method_groups.has_key?(parts[0])
+          method_groups[parts[0]].append(parts[1])
+        else
+          method_groups[parts[0]] = [parts[1]]
+        end
+      end
+      method_groups
+    end
+
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Kodi::Client do
   let(:uri) { "http://xbmc:pass@localhost:8080/jsonrpc" }
-  let(:client) { Kodi::Client.new(uri) }
+  let(:client) { Kodi::Client.new(uri, {'Input' => ['Up'], 'Player' => ['PlayPause']}) }
   subject { client }
 
   it { is_expected.to be_a Kodi::Client }
@@ -11,11 +11,11 @@ describe Kodi::Client do
   describe 'input.up' do
     before do
       stub_request(:post, uri).with(
-        :body => "{\"method\":\"Input.Up\",\"params\":{},\"jsonrpc\":\"2.0\",\"id\":\"1\"}",
+        :body => '{"method":"Input.Up","params":{},"jsonrpc":"2.0","id":"1"}',
         :headers => { 'Content-Type'=>'application/json' }
       ).to_return(
         :status => 200,
-        :body => "{\"id\":\"1\",\"jsonrpc\":\"2.0\",\"result\":\"OK\"}",
+        :body => '{"id":"1","jsonrpc":"2.0","result":"OK"}',
         :headers => {}
       )
     end
@@ -29,11 +29,11 @@ describe Kodi::Client do
   describe 'player.play_pause' do
     before do
       stub_request(:post, uri).with(
-        :body => "{\"method\":\"Player.PlayPause\",\"params\":{\"playerid\":1},\"jsonrpc\":\"2.0\",\"id\":\"1\"}",
+        :body => '{"method":"Player.PlayPause","params":{"playerid":1},"jsonrpc":"2.0","id":"1"}',
         :headers => { 'Content-Type'=>'application/json' }
       ).to_return(
         :status => 200,
-        :body => "{\"id\":\"1\",\"jsonrpc\":\"2.0\",\"result\":\"OK\"}",
+        :body => '{"id":"1","jsonrpc":"2.0","result":"OK"}',
         :headers => {}
       )
     end


### PR DESCRIPTION
I've added the ability to import all available methods in the Kodi JSON-RPC API, by calling the  `JSONRPC.Introspect` method. Creating a new Client with only a URI now uses this feature. If you add a Hash of namespaces and methods, these will be used instead of calling the introspect method.