### PR TITLE
Correct auto-detection of method for namespace

### DIFF
--- a/lib/kodi/namespace.rb
+++ b/lib/kodi/namespace.rb
@@ -10,7 +10,7 @@ module Kodi
 
     def method_missing(method_name, *arguments, &block)
       if method = find_method(method_name)
-        RPC.new(uri).dispatch(name + '.' + method, *arguments)
+        RPC.new(uri).dispatch(name + '.' + method.name, *arguments)
       else
         super
       end
@@ -19,7 +19,7 @@ module Kodi
     private
 
     def find_method(name)
-      @methods.find { |m| m == name.to_s.camelize }
+      @methods.find { |m| m.name == name.to_s.camelize }
     end
   end
 end


### PR DESCRIPTION
elements of @methods field are struct (and not symbols). This patch
makes this gem usable.